### PR TITLE
null named destination in some documents are taken care of.

### DIFF
--- a/src/figure.c
+++ b/src/figure.c
@@ -115,7 +115,6 @@ figure_new(void)
     new_fig->page_num = -1;
     new_fig->image_id = -1;
     new_fig->image_physical_layout = NULL;
-    new_fig->image = NULL;
     new_fig->captions = NULL;
     new_fig->reference = NULL;
     return new_fig;

--- a/src/figure.h
+++ b/src/figure.h
@@ -40,7 +40,6 @@ struct Figure
     int page_num;
     int image_id; /* index given by poppler to images */
     Rect *image_physical_layout;
-    void *image; /* cairo image surface */
 
     GList *captions;
 

--- a/src/toc.c
+++ b/src/toc.c
@@ -144,10 +144,13 @@ toc_find_dest(PopplerDocument *doc,
 			new_dest = poppler_dest_copy(dest);
     		break;
     }
+    if(!new_dest){
+        g_print("Warning: null named destination, link amy not work.\n");
+    }
     TOCItem target;
-    target.offset_x = new_dest->change_left ? new_dest->left : 0;
-	target.offset_y = new_dest->change_top ? new_dest->top : 0;
-	target.page_num = new_dest->page_num - 1;
+    target.offset_x = new_dest ? (new_dest->change_left ? new_dest->left : 0) : 0;
+	target.offset_y = new_dest ? (new_dest->change_top ? new_dest->top : 0) : 0;
+	target.page_num = new_dest ? new_dest->page_num - 1 : -1;
 	poppler_dest_free(new_dest);
 	return target;
 }


### PR DESCRIPTION
image for figures are no longer retained in memory and instead they are created on demand. this reduces memory footprint by up to 50%  and also prevents system hangs(huge memory consumption) when some faulty pdf contains image of all of its pages.